### PR TITLE
Adding support of providing custom name to root element of test report xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ sonarqubeReporter: {
   filePattern: '**/*spec.ts', // test files glob pattern
   outputFolder: 'reports',    // report destination
   encoding: 'utf-8',          // report encoding
+  rootElementName: 'testExecutions', //root element name of the test execution report, default value is testExecutions if you dont provide any value. 
+  /**
+   * For Sonarqube version prior to 6.2, it expects below format for test execution report
+   * 
+   * <unitTest version='1'>
+      <file path='test/webapp/sample/simpleJunitSpec.ts'>
+          <testCase name='Simple Test' duration='2'/>
+      </file>
+    </unitTest>
+
+  From 6.2 onwards, Sonarqube expects below format for test execution report
+
+   <testExecutions version='1'>
+      <file path='test/webapp/sample/simpleJunitSpec.ts'>
+          <testCase name='Simple Test' duration='2'/>
+      </file>
+    </testExecutions>
+
+    To support both format, rootElement property can be be used.
+   */ 
   reportName: (metadata) => { // report name callback
     /**
      * Report metadata array content:
@@ -63,13 +83,22 @@ chrome.65.0.3325.linux.0.0.0.xml
 ```
 The report files' schema is defined on the [SonarQube Generic Test Data][5] page.
 
-Add the following property to your `sonar-project.properties`:
+Add the following property to your `sonar-project.properties`: (For version 6.2 onwards)
 
 ```
 sonar.testExecutionReportPaths= \
   reports/firefox.54.0.0.linux.0.0.0.xml, \
   reports/chrome.65.0.3325.linux.0.0.0.xml
 ```
+
+Add the following property to your `sonar-project.properties`: (For version prior to 6.2)
+
+```
+sonar.genericcoverage.unitTestReportPaths= \
+  reports/firefox.54.0.0.linux.0.0.0.xml, \
+  reports/chrome.65.0.3325.linux.0.0.0.xml
+```
+
 
 Finally, start [SonarQube Scanner][6] on your project folder.
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ sonarqubeReporter: {
   filePattern: '**/*spec.ts', // test files glob pattern
   outputFolder: 'reports',    // report destination
   encoding: 'utf-8',          // report encoding
-  rootElementName: 'testExecutions', //root element name of the test execution report, default value is testExecutions if you dont provide any value. 
+  legacyMode: 'false',        //default value is false, 
 	/**
+   * legacyMode decides the root element name of the test execution report xml, 
+   * legacyMode = true ==> root Element Name will be "testExecutions", legacyMode = false ==> root Element Name will be "unitTest"
+   *
 	 * For Sonarqube version prior to 6.2, it expects below format for test execution report
 	 * 
-	 * <unitTest version='1'>
+	 *  <unitTest version='1'>
 	 *      <file path='test/webapp/sample/simpleJunitSpec.ts'>
 	 *          <testCase name='Simple Test' duration='2'/>
 	 *      </file>
-	 *    </unitTest>
+	 *  </unitTest>
 	 *
 	 *  From 6.2 onwards, Sonarqube expects below format for test execution report
 	 *
@@ -48,7 +51,7 @@ sonarqubeReporter: {
 	 *      </file>
 	 *    </testExecutions>
 	 *
-	 *    To support both format, rootElement property can be be used.
+	 *    To support both format, legacyMode property can be be used.
 	 */ 
   reportName: (metadata) => { // report name callback
     /**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# karma-sonarqube-reporter
+# karma-sonarqube-reporter-custom
 [![npm version](https://img.shields.io/npm/v/karma-sonarqube-reporter.svg?style=flat-square)](https://www.npmjs.com/package/karma-sonarqube-reporter)
 [![Build Status](https://travis-ci.org/fadc80/karma-sonarqube-reporter.svg?branch=master)](https://travis-ci.org/fadc80/karma-sonarqube-reporter)
 [![Coverage Status](https://coveralls.io/repos/github/fadc80/karma-sonarqube-reporter/badge.svg?branch=master)](https://coveralls.io/github/fadc80/karma-sonarqube-reporter?branch=master)  

--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ sonarqubeReporter: {
   outputFolder: 'reports',    // report destination
   encoding: 'utf-8',          // report encoding
   rootElementName: 'testExecutions', //root element name of the test execution report, default value is testExecutions if you dont provide any value. 
-  /**
-   * For Sonarqube version prior to 6.2, it expects below format for test execution report
-   * 
-   * <unitTest version='1'>
-      <file path='test/webapp/sample/simpleJunitSpec.ts'>
-          <testCase name='Simple Test' duration='2'/>
-      </file>
-    </unitTest>
-
-  From 6.2 onwards, Sonarqube expects below format for test execution report
-
-   <testExecutions version='1'>
-      <file path='test/webapp/sample/simpleJunitSpec.ts'>
-          <testCase name='Simple Test' duration='2'/>
-      </file>
-    </testExecutions>
-
-    To support both format, rootElement property can be be used.
-   */ 
+	/**
+	 * For Sonarqube version prior to 6.2, it expects below format for test execution report
+	 * 
+	 * <unitTest version='1'>
+	 *      <file path='test/webapp/sample/simpleJunitSpec.ts'>
+	 *          <testCase name='Simple Test' duration='2'/>
+	 *      </file>
+	 *    </unitTest>
+	 *
+	 *  From 6.2 onwards, Sonarqube expects below format for test execution report
+	 *
+	 *   <testExecutions version='1'>
+	 *      <file path='test/webapp/sample/simpleJunitSpec.ts'>
+	 *          <testCase name='Simple Test' duration='2'/>
+	 *      </file>
+	 *    </testExecutions>
+	 *
+	 *    To support both format, rootElement property can be be used.
+	 */ 
   reportName: (metadata) => { // report name callback
     /**
      * Report metadata array content:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# karma-sonarqube-reporter-custom
+# karma-sonarqube-reporter
 [![npm version](https://img.shields.io/npm/v/karma-sonarqube-reporter.svg?style=flat-square)](https://www.npmjs.com/package/karma-sonarqube-reporter)
 [![Build Status](https://travis-ci.org/fadc80/karma-sonarqube-reporter.svg?branch=master)](https://travis-ci.org/fadc80/karma-sonarqube-reporter)
 [![Coverage Status](https://coveralls.io/repos/github/fadc80/karma-sonarqube-reporter/badge.svg?branch=master)](https://coveralls.io/github/fadc80/karma-sonarqube-reporter?branch=master)  

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const ENCODING = 'utf-8';
 const REPORT_NAME = (metadata) => {
     return metadata.concat('xml').join('.');
 }
-const DEFAULT_ROOT_ELEMENT_NAME = 'testExecutions';
 
 var sonarqubeReporter = function(baseReporterDecorator, config,
   logger, helper, formatError) {
@@ -27,7 +26,7 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
   var outputFolder = sonarqubeConfig.outputFolder || OUTPUT_FOLDER;
   var encoding = sonarqubeConfig.encoding || ENCODING;
   var reportName = sonarqubeConfig.reportName || REPORT_NAME;
-  var rootElementName = sonarqubeConfig.rootElementName || DEFAULT_ROOT_ELEMENT_NAME;
+  var rootElementName = sonarqubeConfig.legacyMode ? 'unitTest' : 'testExecutions';
 
   var paths = pathfinder.parseTestFiles(
     pattern, encoding);
@@ -79,7 +78,7 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
   };
 
   this.onRunComplete = function(browsersCollection, results) {
-    saveReports(outputFolder, reports,rootElementName);
+    saveReports(outputFolder, reports, rootElementName);
   };
 };
 
@@ -113,7 +112,7 @@ function stacktrace(result, formatError) {
 function saveReports(folder, reports, rootElementName) {
   Object.keys(reports).forEach((report) => {
     saveReport(path.join(folder, report),
-      reports[report],rootElementName);
+      reports[report], rootElementName);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const ENCODING = 'utf-8';
 const REPORT_NAME = (metadata) => {
     return metadata.concat('xml').join('.');
 }
+const DEFAULT_ROOT_ELEMENT_NAME = 'testExecutions';
 
 var sonarqubeReporter = function(baseReporterDecorator, config,
   logger, helper, formatError) {
@@ -26,6 +27,7 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
   var outputFolder = sonarqubeConfig.outputFolder || OUTPUT_FOLDER;
   var encoding = sonarqubeConfig.encoding || ENCODING;
   var reportName = sonarqubeConfig.reportName || REPORT_NAME;
+  var rootElementName = sonarqubeConfig.rootElementName || DEFAULT_ROOT_ELEMENT_NAME;
 
   var paths = pathfinder.parseTestFiles(
     pattern, encoding);
@@ -77,7 +79,7 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
   };
 
   this.onRunComplete = function(browsersCollection, results) {
-    saveReports(outputFolder, reports);
+    saveReports(outputFolder, reports,rootElementName);
   };
 };
 
@@ -108,16 +110,16 @@ function stacktrace(result, formatError) {
     (errors, value)=> { return errors.concat(value) });
 }
 
-function saveReports(folder, reports) {
+function saveReports(folder, reports, rootElementName) {
   Object.keys(reports).forEach((report) => {
     saveReport(path.join(folder, report),
-      reports[report]);
+      reports[report],rootElementName);
   });
 }
 
-function saveReport(filePath, data) {
+function saveReport(filePath, data, rootElementName) {
   createFolder(filePath);
-  createFile(filePath, data);
+  createFile(filePath, data, rootElementName);
 }
 
 function createFolder(filePath) {
@@ -126,16 +128,16 @@ function createFolder(filePath) {
   );
 }
 
-function createFile(filePath, data) {
-  fs.writeFileSync(filePath, toXml(data));
+function createFile(filePath, data, rootElementName) {
+  fs.writeFileSync(filePath, toXml(data, rootElementName));
 }
 
 function metadata(report) {
   return report.replace(/\(|\)/gm,'').split(" ");
 }
 
-function toXml(report) {
-  return js2xmlparser.parse('testExecutions', report);
+function toXml(report, rootElementName) {
+  return js2xmlparser.parse(rootElementName, report);
 }
 
 sonarqubeReporter.$inject = [

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "karma-sonarqube-reporter-custom",
+  "name": "karma-sonarqube-reporter",
   "version": "1.1.1",
-  "description": "A karma reporter plugin for generating Sonarqube generic test reports, also supports backward compatibility",
+  "description": "A karma reporter plugin for generating Sonarqube generic test reports",
   "main": "index.js",
   "scripts": {
     "test": "nyc jasmine && nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sohansoni/karma-sonarqube-reporter.git"
+    "url": "git+https://github.com/fadc80/karma-sonarqube-reporter.git"
   },
   "keywords": [
     "karma-reporter",
     "sonarqube"
   ],
-  "author": "Sohan Soni",
+  "author": "Fernando Costa",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fadc80/karma-sonarqube-reporter/issues"
   },
-  "homepage": "https://github.com/sohansoni/karma-sonarqube-reporter#readme",
+  "homepage": "https://github.com/fadc80/karma-sonarqube-reporter#readme",
   "dependencies": {
     "clone-regexp": "^1.0.1",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "karma-sonarqube-reporter",
+  "name": "karma-sonarqube-reporter-custom",
   "version": "1.1.1",
-  "description": "A karma reporter plugin for generating Sonarqube generic test reports",
+  "description": "A karma reporter plugin for generating Sonarqube generic test reports, also supports backward compatibility",
   "main": "index.js",
   "scripts": {
     "test": "nyc jasmine && nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fadc80/karma-sonarqube-reporter.git"
+    "url": "git+https://github.com/sohansoni/karma-sonarqube-reporter.git"
   },
   "keywords": [
     "karma-reporter",
     "sonarqube"
   ],
-  "author": "Fernando Costa",
+  "author": "Sohan Soni",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fadc80/karma-sonarqube-reporter/issues"
   },
-  "homepage": "https://github.com/fadc80/karma-sonarqube-reporter#readme",
+  "homepage": "https://github.com/sohansoni/karma-sonarqube-reporter#readme",
   "dependencies": {
     "clone-regexp": "^1.0.1",
     "glob": "^7.1.2",


### PR DESCRIPTION
For Sonarqube version prior to 6.2, it expects below format for test execution report

	<unitTest version='1'>
     <file path='test/webapp/sample/simpleJunitSpec.ts'>
         <testCase name='Simple Test' duration='2'/>
     </file>
   </unitTest>

From 6.2 onwards, Sonarqube expects below format for test execution report

  <testExecutions version='1'>
     <file path='test/webapp/sample/simpleJunitSpec.ts'>
         <testCase name='Simple Test' duration='2'/>
     </file>
   </testExecutions>

To support both format, rootElement property can be be used.