### PR TITLE
feat: make report name accept a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sonarqubeReporter: {
   encoding: 'utf-8',          // test files encoding
   outputFolder: 'reports',    // report destination
   legacyMode: false,          // report for Sonarqube < 6.2 (disabled)
-  reportName: (metadata) => { // report name callback
+  reportName: (metadata) => { // report name callback, accepts also a string (reportName: 'report.xml') to generate a single file
     /**
      * Report metadata array:
      * - metadata[0] = browser name

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
 
   var outputFolder = sonarqubeConfig.outputFolder || OUTPUT_FOLDER;
   var encoding = sonarqubeConfig.encoding || ENCODING;
-  var reportName = sonarqubeConfig.reportName || REPORT_NAME;
+  var reportName = (typeof sonarqubeConfig.reportName === 'string')
+    ? () => sonarqubeConfig.reportName
+    : sonarqubeConfig.reportName || REPORT_NAME;
   var legacyMode = sonarqubeConfig.legacyMode || LEGACY_MODE;
 
   var paths = pathfinder.parseTestFiles(

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -22,10 +22,7 @@ const config2 = {
     outputFolder: 'reports/config2',
     encoding: 'iso-8859-1',
     legacyMode: true,
-    reportName: (metadata) => {
-      return metadata[0].concat(
-        '/result.xml');
-    }
+    reportName: 'result.xml'
   }
 };
 
@@ -180,7 +177,7 @@ describe('Sonarqube reporter tests', function() {
           suite: ['s3'], description: 'd3', time: '3', log: ['e3']});
         reporterConfig2.onRunComplete({}, {});
 
-        const reportFilePath = 'reports/config2/ie/result.xml';
+        const reportFilePath = 'reports/config2/result.xml';
 
         expect(reporterConfig2.specFailure.calls.count()).toEqual(3);
         expect(isReportFileCreated(reportFilePath)).toBe(true);
@@ -258,9 +255,7 @@ describe('Sonarqube reporter tests', function() {
 
         expect(reporterConfig2.specFailure.calls.count()).toEqual(3);
 
-        expect(isReportFileCreated('reports/config2/firefox/result.xml')).toBe(true);
-        expect(isReportFileCreated('reports/config2/chrome/result.xml')).toBe(true);
-        expect(isReportFileCreated('reports/config2/ie/result.xml')).toBe(true);
+        expect(isReportFileCreated('reports/config2/result.xml')).toBe(true);
       });
     });
   });


### PR DESCRIPTION
This merge request extends report name to accept a string in additon to the callback function which allows you to generate a single file.

### Before
```js
sonarqubeReporter: {
    reportName: (metadata) => {}
}
```

### After
```js
sonarqubeReporter: {
    reportName: 'report.xml' || (metadata) => {}
}
```

Closes #16