### PR TITLE
fix: reporting jasmine skipped tests properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,11 +41,11 @@ var sonarqubeReporter = function(baseReporterDecorator, config,
   this.adapters = [];
 
   this.onSpecComplete = function(browser, result) {
-    if (result.success) {
-      this.specSuccess(browser, result);
-    }
-    else if (result.skipped) {
+    if (result.skipped) {
       this.specSkipped(browser, result);
+    }
+    else if (result.success) {
+      this.specSuccess(browser, result);
     }
     else {
       this.specFailure(browser, result);

--- a/lib/path-finder.js
+++ b/lib/path-finder.js
@@ -60,7 +60,6 @@ function existIt(paths, path, it) {
 }
 
 function regexPattern() {
-  // https://regex101.com/r/HUyh3u/1
   return /((\S{0,2}describe?[^(]+)|(\s\S{0,2}it?[^(]+))\s*\(\s*((?<![\\])[`'"])((?:.(?!(?<![\\])\4))*.?)\4/gi;
 }
 

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -133,11 +133,11 @@ describe('Sonarqube reporter tests', function() {
       it('All test cases skipped (chrome)', function() {
 
         reporterConfig1.onSpecComplete({name: chrome}, {
-          skipped: true, suite: ['s1'], description: 'd1', time: '1'});
+          success:true, skipped: true, suite: ['s1'], description: 'd1', time: '1'});
         reporterConfig1.onSpecComplete({name: chrome}, { fullName: 's2#d2',
-          skipped: true, suite: ['s2'], description: 'd2', time: '2'});
+          success:true, skipped: true, suite: ['s2'], description: 'd2', time: '2'});
         reporterConfig1.onSpecComplete({name: chrome}, { fullName: 's3#d3',
-          skipped: true, suite: ['s3'], description: 'd3', time: '3'});
+          success:true, skipped: true, suite: ['s3'], description: 'd3', time: '3'});
         reporterConfig1.onRunComplete({}, {});
 
         const reportFilePath = 'reports/config1/chrome.xml';
@@ -227,11 +227,11 @@ describe('Sonarqube reporter tests', function() {
       it('All test cases skipped', function() {
 
         reporterConfig1.onSpecComplete({name: firefox}, {
-          skipped: true, suite: ['s2'], description: 'd2', time: '2'});
+          success:true, skipped: true, suite: ['s2'], description: 'd2', time: '2'});
         reporterConfig1.onSpecComplete({name: chrome}, { fullName: 's2#d2',
-          skipped: true, suite: ['s2'], description: 'd2', time: '2'});
+          success:true, skipped: true, suite: ['s2'], description: 'd2', time: '2'});
         reporterConfig1.onSpecComplete({name: ie}, { fullName: 's2#d2',
-          skipped: true, suite: ['s2'], description: 'd2', time: '2'});
+          success:true, skipped: true, suite: ['s2'], description: 'd2', time: '2'});
         reporterConfig1.onRunComplete({}, {});
 
         expect(reporterConfig1.specSkipped.calls.count()).toEqual(3);


### PR DESCRIPTION
Now first we check `result.skipped` and then `result.success`.