### PR TITLE
Fix #97 Only display describe and it name when test file is not found

### DIFF
--- a/lib/path-finder.js
+++ b/lib/path-finder.js
@@ -38,8 +38,7 @@ function testFile(paths, describe, it) {
   var testFile = Object.keys(paths).find(path =>
     exist(paths, path, describe, it));
   if (testFile === undefined) {
-    logger.error('Test file path not found! %s | %s | %s',
-        JSON.stringify(paths), describe, it);
+    logger.error('Test file path not found! %s | %s', describe, it);
   }
   return testFile;
 }


### PR DESCRIPTION
The number of path is really enormous when you have even only 100 unit tests and not helpful to determine which test raised the error since the console can't print all the data.