### PR TITLE
Basic support for dynamic tests with interpolation

### DIFF
--- a/lib/path-finder.js
+++ b/lib/path-finder.js
@@ -29,13 +29,13 @@ function parseTestFile(paths, path, data) {
     if (type.includes("describe")) {
         paths[path].describe.push(text);
         if (templateRegex.test(text)) {
-          paths[path].dynamicDescribe.push(new RegExp(text.replace(templateRegex, ".*")));
+          paths[path].dynamicDescribe.push(toDynamicNameRegExp(text));
         }
     }
     if (type.includes("it")) {
         paths[path].it.push(text);
         if (templateRegex.test(text)) {
-          paths[path].dynamicIt.push(new RegExp(text.replace(templateRegex, ".*")));
+          paths[path].dynamicIt.push(toDynamicNameRegExp(text));
         }
     }
   }
@@ -89,7 +89,7 @@ function regexPattern() {
 
 function templateLiteralRegex() {
   // supports 5 levels of nested curly braces
-  return /\$(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*})/g;
+  return /\$(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*})/;
 }
 
 function removeEscapedQuotes(str) {
@@ -106,6 +106,13 @@ function removeMultilineDelimiters(str) {
 
 function removeNewLines(data) {
     return data.replace(/\r?\n|\r/g, '');
+}
+
+function toDynamicNameRegExp(string) {
+  var templateGlobalRegex = new RegExp(templateLiteralRegex().source, 'g');
+  return new RegExp(string
+      .replace(templateGlobalRegex, ".*")
+      .replace(/[+?^${}()|[\]\\]|\.(?!\*)|(?<!\.)\*/g, '\\$&')); // escape special regexp characters
 }
 
 module.exports = {

--- a/lib/path-finder.js
+++ b/lib/path-finder.js
@@ -19,17 +19,24 @@ function testFileData(path, encoding) {
 
 function parseTestFile(paths, path, data) {
   var result, regex = regexPattern();
+  var templateRegex = templateLiteralRegex();
   while ((result = regex.exec(data)) != null) {
     var type = result[2] || result[3];
     var text = result[5];
     if (paths[path] == undefined) {
-        paths[path] = { describe: [], it: [] };
+        paths[path] = { describe: [], dynamicDescribe: [], it: [], dynamicIt: [] };
     }
     if (type.includes("describe")) {
         paths[path].describe.push(text);
+        if (templateRegex.test(text)) {
+          paths[path].dynamicDescribe.push(new RegExp(text.replace(templateRegex, ".*")));
+        }
     }
     if (type.includes("it")) {
         paths[path].it.push(text);
+        if (templateRegex.test(text)) {
+          paths[path].dynamicIt.push(new RegExp(text.replace(templateRegex, ".*")));
+        }
     }
   }
 }
@@ -49,17 +56,40 @@ function exist(paths, path, describe, it) {
 }
 
 function existDescribe(paths, path, describe) {
-    return paths[path].describe.find(element =>
-      describe.startsWith(removeEscapedQuotes(element)));
+    if (paths[path].describe.find(element =>
+        describe === removeEscapedQuotes(element))) {
+      return true;
+    }
+    var dynamicDescribes = paths[path].dynamicDescribe
+        .filter(element => element.test(describe));
+    if (dynamicDescribes.length > 1) {
+      logger.error('Multiple dynamic describes found matching test name! %s', dynamicDescribes);
+      return undefined;
+    }
+    return dynamicDescribes[0];
 }
 
 function existIt(paths, path, it) {
-    return paths[path].it.find(element =>
-      it.startsWith(removeEscapedQuotes(element)));
+  if (paths[path].it.find(element =>
+      it === removeEscapedQuotes(element))) {
+      return true;
+  }
+  var dynamicIts = paths[path].dynamicIt
+      .filter(element => element.test(it));
+  if (dynamicIts.length > 1) {
+    logger.error('Multiple dynamic its found matching test name! %s', dynamicIts);
+    return undefined;
+  }
+  return dynamicIts[0];
 }
 
 function regexPattern() {
   return /((\S{0,2}describe?[^(]+)|(\s\S{0,2}it?[^(]+))\s*\(\s*((?<![\\])[`'"])((?:.(?!(?<![\\])\4))*.?)\4/gi;
+}
+
+function templateLiteralRegex() {
+  // supports 5 levels of nested curly braces
+  return /\$(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*(?:{[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*}[^{}]*)*[^{}]*})/g;
 }
 
 function removeEscapedQuotes(str) {

--- a/lib/path-finder.js
+++ b/lib/path-finder.js
@@ -22,7 +22,7 @@ function parseTestFile(paths, path, data) {
   var templateRegex = templateLiteralRegex();
   while ((result = regex.exec(data)) != null) {
     var type = result[2] || result[3];
-    var text = result[5];
+    var text = removeMultilineDelimiters(result[4]);
     if (paths[path] == undefined) {
         paths[path] = { describe: [], dynamicDescribe: [], it: [], dynamicIt: [] };
     }
@@ -84,7 +84,7 @@ function existIt(paths, path, it) {
 }
 
 function regexPattern() {
-  return /((\S{0,2}describe?[^(]+)|(\s\S{0,2}it?[^(]+))\s*\(\s*((?<![\\])[`'"])((?:.(?!(?<![\\])\4))*.?)\4/gi;
+  return /((\S{0,2}describe?[^(]+)|(\s\S{0,2}it?[^(]+))\s*\(\s*((?:(?:\s*\+\s*)?((?<![\\])[`'"])(?:.(?!(?<![\\])\5))*.?\5)+)/gi;
 }
 
 function templateLiteralRegex() {
@@ -98,6 +98,10 @@ function removeEscapedQuotes(str) {
 
 function removeComments(data) {
     return data.replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, '');
+}
+
+function removeMultilineDelimiters(str) {
+    return str.replace(/^[`'"]|[`'"]$/g, '').replace(/[`'"]\s*\+\s*[`'"]/g, '')
 }
 
 function removeNewLines(data) {

--- a/spec/lib/path-finder.spec.js
+++ b/spec/lib/path-finder.spec.js
@@ -13,7 +13,9 @@ const testFileData = {
     'describe(\'s7.2\', function() { it(\'d7.2\', function() {}); });' +
     'describe(\'s7.3\', function() { it(\'d7.3\', function() {}); });' +
     'describe(\'s7.4\', function() { describe(\'s7.4.1\'+\'text\', function() { ' +
-      'it(\'d7.4.1\'+\'text\', function() {}); }); });',
+      'it(\'d7.4.1\'+\'text\', function() {}); }); });' +
+    'describe(\'s7.5\', function() { describe(\'s7.5.1\' + \n\' text\', function() { ' +
+      'it(\'d7.5.1\' + \n\' text\', function() {}); }); });',
   'path/t8.spec.js': 'describe.skip(\'s8\', function() { it.skip(\'d8\', function() {}); });',
   'path/t9.spec.js':'describe(\'s9\', function() { xit(\'d9.1\', function() {}); });' +
     'describe(\'s9.2\', function() { it.skip(\'d9.2\', function() {}); });' +
@@ -38,11 +40,11 @@ const parsedTestFiles = {
   'path/t5.spec.js': { describe: ['\\\"s5\\\"'], dynamicDescribe: [], it: ['\\\"d5\\\"'], dynamicIt: [] },
   'path/t6.spec.js': { describe: ['s6\"\\\\\'\\\\\'\"'], dynamicDescribe: [],
       it: ['d6\"\\\\\'\\\\\'\"'], dynamicIt: [] },
-  'path/t7.spec.js': { describe: ['s7', 's7.2', 's7.3', 's7.4', 's7.4.1'], dynamicDescribe: [],
-      it: ['d7.1', 'd7.2', 'd7.3', 'd7.4.1'], dynamicIt: [] },
+  'path/t7.spec.js': { describe: ['s7', 's7.2', 's7.3', 's7.4', 's7.4.1text', 's7.5', 's7.5.1 text'], dynamicDescribe: [],
+      it: ['d7.1', 'd7.2', 'd7.3', 'd7.4.1text', 'd7.5.1 text'], dynamicIt: [] },
   'path/t8.spec.js': { describe: ['s8'], dynamicDescribe: [], it: ['d8'], dynamicIt: [] },
-  'path/t9.spec.js': { describe: ['s9', 's9.2', 's9.3', 's9.4', 's9.4.1'], dynamicDescribe: [],
-      it: ['d9.1', 'd9.2', 'd9.3', 'd9.4.1'], dynamicIt: [] },
+  'path/t9.spec.js': { describe: ['s9', 's9.2', 's9.3', 's9.4', 's9.4.1text'], dynamicDescribe: [],
+      it: ['d9.1', 'd9.2', 'd9.3', 'd9.4.1text'], dynamicIt: [] },
   'path/t10.spec.js': {
     describe: ['s10', 's10.2 ${someVar}', 's10.2 clash ${someVar}', 's10.3 ${someVar} multiple ${someVar}',
       's10.4', 's10.4.2', 's10.5'],
@@ -169,8 +171,8 @@ describe('Path finder tests', function() {
       it('7th test file match suite 7.4.1 and description 7.4.1 (nested)', function() {
         var paths = pathFinder.parseTestFiles('**/*.spec.ts', 'utf-8');
         var path = paths['path/t7.spec.js'];
-        expect(path.describe[4]).toBe('s7.4.1');
-        expect(path.it[3]).toBe('d7.4.1');
+        expect(path.describe[4]).toBe('s7.4.1text');
+        expect(path.it[3]).toBe('d7.4.1text');
       });
 
       it("9st test file match suite 9 and description 9 with skipped test", function() {
@@ -228,6 +230,7 @@ describe('Path finder tests', function() {
       expect(pathFinder.testFile(parsedTestFiles, 's7',  'd7.1')).toBe('path/t7.spec.js');
       expect(pathFinder.testFile(parsedTestFiles, 's7.2', 'd7.2')).toBe('path/t7.spec.js');
       expect(pathFinder.testFile(parsedTestFiles, 's7.3', 'd7.3')).toBe('path/t7.spec.js');
+      expect(pathFinder.testFile(parsedTestFiles, 's7.4.1text', 'd7.4.1text')).toBe('path/t7.spec.js');
     });
 
     it('Suite 10 and description 10 found in test file 10', function() {

--- a/spec/lib/path-finder.spec.js
+++ b/spec/lib/path-finder.spec.js
@@ -29,7 +29,8 @@ const testFileData = {
       'describe(\'s10.4\', function() { it(\'d10.4 ${array.map(v => `nested ${v}`)}\', function() {}); });' +
       'describe(\'s10.4.2\', function() { it(\'d10.4 clash ${someVar}\', function() {}); });' +
       'describe(\'s10.5\', function() { ' +
-        'it(\'d10.5 ${array.map(v => if (something) { return { a: `a` }} return { a: `b`}}\', function() {}); });',
+        'it(\'d10.5 ${array.map(v => if (something) { return { a: `a` }} return { a: `b`}}\', function() {}); });' +
+      'describe(\'s10.6\', function() { it(\'d10.6 + [${someVar}]\', function() {}); });',
 }
 
 const parsedTestFiles = {
@@ -47,11 +48,12 @@ const parsedTestFiles = {
       it: ['d9.1', 'd9.2', 'd9.3', 'd9.4.1text'], dynamicIt: [] },
   'path/t10.spec.js': {
     describe: ['s10', 's10.2 ${someVar}', 's10.2 clash ${someVar}', 's10.3 ${someVar} multiple ${someVar}',
-      's10.4', 's10.4.2', 's10.5'],
-    dynamicDescribe: [/s10.2 .*/, /s10.2 clash .*/, /s10.3 .* multiple .*/],
+      's10.4', 's10.4.2', 's10.5', 's10.6'],
+    dynamicDescribe: [/s10\.2 .*/, /s10\.2 clash .*/, /s10\.3 .* multiple .*/],
     it: ['d10.1 ${someVar} multi ${someVar}', 'd10.2', 'd10.2', 'd10.3', 'd10.4 ${array.map(v => `nested ${v}`)}',
-      'd10.4 clash ${someVar}', 'd10.5 ${array.map(v => if (something) { return { a: `a` }} return { a: `b`}}'],
-    dynamicIt: [/d10.1 .* multi .*/, /d10.4 .*/, /d10.4 clash .*/, /d10.5 .*/] }
+      'd10.4 clash ${someVar}', 'd10.5 ${array.map(v => if (something) { return { a: `a` }} return { a: `b`}}',
+      'd10.6 + [${someVar}]'],
+    dynamicIt: [/d10\.1 .* multi .*/, /d10\.4 .*/, /d10\.4 clash .*/, /d10\.5 .*/, /d10\.6 \+ \[.*\]/] }
 }
 
 describe('Path finder tests', function() {


### PR DESCRIPTION
Adds basic support for dynamic tests (#18). I think this would cover most of the cases where dynamic tests with interpolated names are used. 
Edges cases:
 - when multiple dynamic tests match the same pattern - in this case you'd need to reword the test name or add some text to the static part of the name so that it wouldn't clash.
 - concating object to a string like `'name_'+variable` - in this case you'd need to adjust to use interpolation `name_${variable}`

Also adds support for multiline test names as using `startWith` to find test file is not really accurate, just because of multiline bug (#7)